### PR TITLE
Compatibility with Devel::StackTrace 2.00

### DIFF
--- a/lib/Devel/REPL/Plugin/Carp/REPL.pm
+++ b/lib/Devel/REPL/Plugin/Carp/REPL.pm
@@ -17,6 +17,7 @@ has stacktrace => (
     default => sub {
         my $stacktrace = Devel::StackTrace::WithLexicals->new(
             ignore_class => ['Carp::REPL', __PACKAGE__],
+            unsafe_ref_capture => 1,
         );
 
         # skip all the Moose metaclass frames


### PR DESCRIPTION
Patch provided by DAKKAR@cpan.org on [rt.cpan.org #100314]:

```
Devel::StackTrace 2.00 defaults to returning strings, not refs, in the
stack frames. This is to prevent memory leaks all over the place.

We don't really care about leaks in a REPL, so we can just turn the
refs back on.
```
